### PR TITLE
from partial implementation for #85

### DIFF
--- a/packages/ast/src/encoding/proto/__tests__/__snapshots__/contracts.test.ts.snap
+++ b/packages/ast/src/encoding/proto/__tests__/__snapshots__/contracts.test.ts.snap
@@ -101,7 +101,7 @@ exports[`MsgExecuteContract interface 2`] = `
     const message = createBaseMsgExecuteContract();
     message.sender = object.sender ?? \\"\\";
     message.contract = object.contract ?? \\"\\";
-    message.msg = object.msg ?? new Uint8Array();
+    message.msg = toUtf8(JSON.stringify(object.msg ?? new Uint8Array()));
     message.funds = object.funds?.map(e => Coin.fromPartial(e)) || [];
     return message;
   }

--- a/packages/ast/src/encoding/proto/from-partial/index.ts
+++ b/packages/ast/src/encoding/proto/from-partial/index.ts
@@ -65,6 +65,7 @@ export const fromPartialMethodFields = (context: ProtoParseContext, name: string
 
         }
 
+        // key types
         if (field.keyType) {
             switch (field.keyType) {
                 case 'string':
@@ -78,11 +79,17 @@ export const fromPartialMethodFields = (context: ProtoParseContext, name: string
             }
         }
 
+        // scalar types
         switch (field.type) {
             case 'string':
                 return fromPartial.string(args);
             case 'bytes':
-                return fromPartial.bytes(args);
+                switch (field.options?.['(gogoproto.casttype)']) {
+                    case 'RawContractMessage':
+                        return fromPartial.rawContractMessage(args);
+                    default:
+                        return fromPartial.bytes(args);
+                }
             case 'bool':
                 return fromPartial.bool(args);
             case 'double':

--- a/packages/ast/src/encoding/proto/types.ts
+++ b/packages/ast/src/encoding/proto/types.ts
@@ -45,11 +45,12 @@ export interface ProtoField {
     options: {
         [key: string]: any;
         deprecated?: boolean;
-        "(gogoproto.nullable)"?: boolean;
+        "(cosmos_proto.accepts_interface)"?: string;
         "(cosmos_proto.scalar)"?: string;
+        "(gogoproto.casttype)"?: string;
         "(gogoproto.customtype)"?: string;
         "(gogoproto.moretags)"?: string;
-        "(cosmos_proto.accepts_interface)"?: string;
+        "(gogoproto.nullable)"?: boolean;
     }
     comment?: string;
     import?: string;


### PR DESCRIPTION
This is a potential solution for calling `toUtf8`/`JSON.stringify` for the `msg` prop in `MsgExecuteContract`.

This is a generalized system, however, as we can parse the proto options `[ (gogoproto.casttype) = "RawContractMessage" ]`

https://github.com/CosmWasm/wasmd/blob/main/proto/cosmwasm/wasm/v1/tx.proto#L58