### PR TITLE
handled cosmos sdk decimal under a flag

### DIFF
--- a/__fixtures__/v-next/outputv4/akash/inflation/v1beta2/params.ts
+++ b/__fixtures__/v-next/outputv4/akash/inflation/v1beta2/params.ts
@@ -1,4 +1,5 @@
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Exact } from "../../../helpers";
 export const protobufPackage = "akash.inflation.v1beta2";
 
@@ -38,15 +39,15 @@ function createBaseParams(): Params {
 export const Params = {
   encode(message: Params, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.inflationDecayFactor !== "") {
-      writer.uint32(10).string(message.inflationDecayFactor);
+      writer.uint32(10).string(Decimal.fromUserInput(message.inflationDecayFactor, 18).atomics);
     }
 
     if (message.initialInflation !== "") {
-      writer.uint32(18).string(message.initialInflation);
+      writer.uint32(18).string(Decimal.fromUserInput(message.initialInflation, 18).atomics);
     }
 
     if (message.variance !== "") {
-      writer.uint32(26).string(message.variance);
+      writer.uint32(26).string(Decimal.fromUserInput(message.variance, 18).atomics);
     }
 
     return writer;
@@ -62,15 +63,15 @@ export const Params = {
 
       switch (tag >>> 3) {
         case 1:
-          message.inflationDecayFactor = reader.string();
+          message.inflationDecayFactor = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.initialInflation = reader.string();
+          message.initialInflation = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.variance = reader.string();
+          message.variance = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/distribution.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/distribution.ts
@@ -1,5 +1,6 @@
 import { DecCoin, DecCoinSDKType, Coin, CoinSDKType } from "../../base/v1beta1/coin";
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Long } from "../../../helpers";
 export const protobufPackage = "cosmos.distribution.v1beta1";
 
@@ -257,15 +258,15 @@ function createBaseParams(): Params {
 export const Params = {
   encode(message: Params, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.communityTax !== "") {
-      writer.uint32(10).string(message.communityTax);
+      writer.uint32(10).string(Decimal.fromUserInput(message.communityTax, 18).atomics);
     }
 
     if (message.baseProposerReward !== "") {
-      writer.uint32(18).string(message.baseProposerReward);
+      writer.uint32(18).string(Decimal.fromUserInput(message.baseProposerReward, 18).atomics);
     }
 
     if (message.bonusProposerReward !== "") {
-      writer.uint32(26).string(message.bonusProposerReward);
+      writer.uint32(26).string(Decimal.fromUserInput(message.bonusProposerReward, 18).atomics);
     }
 
     if (message.withdrawAddrEnabled === true) {
@@ -285,15 +286,15 @@ export const Params = {
 
       switch (tag >>> 3) {
         case 1:
-          message.communityTax = reader.string();
+          message.communityTax = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.baseProposerReward = reader.string();
+          message.baseProposerReward = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.bonusProposerReward = reader.string();
+          message.bonusProposerReward = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:
@@ -757,7 +758,7 @@ export const ValidatorSlashEvent = {
     }
 
     if (message.fraction !== "") {
-      writer.uint32(18).string(message.fraction);
+      writer.uint32(18).string(Decimal.fromUserInput(message.fraction, 18).atomics);
     }
 
     return writer;
@@ -777,7 +778,7 @@ export const ValidatorSlashEvent = {
           break;
 
         case 2:
-          message.fraction = reader.string();
+          message.fraction = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -1154,7 +1155,7 @@ export const DelegatorStartingInfo = {
     }
 
     if (message.stake !== "") {
-      writer.uint32(18).string(message.stake);
+      writer.uint32(18).string(Decimal.fromUserInput(message.stake, 18).atomics);
     }
 
     if (!message.height.isZero()) {
@@ -1178,7 +1179,7 @@ export const DelegatorStartingInfo = {
           break;
 
         case 2:
-          message.stake = reader.string();
+          message.stake = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/gov.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/gov.ts
@@ -3,6 +3,7 @@ import { Any, AnySDKType } from "../../../google/protobuf/any";
 import { Timestamp, TimestampSDKType } from "../../../google/protobuf/timestamp";
 import { Duration, DurationSDKType } from "../../../google/protobuf/duration";
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Long, toTimestamp, fromTimestamp, bytesFromBase64, base64FromBytes } from "../../../helpers";
 export const protobufPackage = "cosmos.gov.v1beta1";
 
@@ -379,7 +380,7 @@ export const WeightedVoteOption = {
     }
 
     if (message.weight !== "") {
-      writer.uint32(18).string(message.weight);
+      writer.uint32(18).string(Decimal.fromUserInput(message.weight, 18).atomics);
     }
 
     return writer;
@@ -399,7 +400,7 @@ export const WeightedVoteOption = {
           break;
 
         case 2:
-          message.weight = reader.string();
+          message.weight = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/cosmos/mint/v1beta1/mint.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/mint/v1beta1/mint.ts
@@ -1,4 +1,5 @@
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Long } from "../../../helpers";
 export const protobufPackage = "cosmos.mint.v1beta1";
 
@@ -58,11 +59,11 @@ function createBaseMinter(): Minter {
 export const Minter = {
   encode(message: Minter, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.inflation !== "") {
-      writer.uint32(10).string(message.inflation);
+      writer.uint32(10).string(Decimal.fromUserInput(message.inflation, 18).atomics);
     }
 
     if (message.annualProvisions !== "") {
-      writer.uint32(18).string(message.annualProvisions);
+      writer.uint32(18).string(Decimal.fromUserInput(message.annualProvisions, 18).atomics);
     }
 
     return writer;
@@ -78,11 +79,11 @@ export const Minter = {
 
       switch (tag >>> 3) {
         case 1:
-          message.inflation = reader.string();
+          message.inflation = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.annualProvisions = reader.string();
+          message.annualProvisions = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -156,19 +157,19 @@ export const Params = {
     }
 
     if (message.inflationRateChange !== "") {
-      writer.uint32(18).string(message.inflationRateChange);
+      writer.uint32(18).string(Decimal.fromUserInput(message.inflationRateChange, 18).atomics);
     }
 
     if (message.inflationMax !== "") {
-      writer.uint32(26).string(message.inflationMax);
+      writer.uint32(26).string(Decimal.fromUserInput(message.inflationMax, 18).atomics);
     }
 
     if (message.inflationMin !== "") {
-      writer.uint32(34).string(message.inflationMin);
+      writer.uint32(34).string(Decimal.fromUserInput(message.inflationMin, 18).atomics);
     }
 
     if (message.goalBonded !== "") {
-      writer.uint32(42).string(message.goalBonded);
+      writer.uint32(42).string(Decimal.fromUserInput(message.goalBonded, 18).atomics);
     }
 
     if (!message.blocksPerYear.isZero()) {
@@ -192,19 +193,19 @@ export const Params = {
           break;
 
         case 2:
-          message.inflationRateChange = reader.string();
+          message.inflationRateChange = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.inflationMax = reader.string();
+          message.inflationMax = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:
-          message.inflationMin = reader.string();
+          message.inflationMin = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 5:
-          message.goalBonded = reader.string();
+          message.goalBonded = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 6:

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/staking.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/staking.ts
@@ -5,6 +5,7 @@ import { Duration, DurationSDKType } from "../../../google/protobuf/duration";
 import { Coin, CoinSDKType } from "../../base/v1beta1/coin";
 import * as _m0 from "protobufjs/minimal";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp, Long } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "cosmos.staking.v1beta1";
 
 /** BondStatus is the status of a validator. */
@@ -646,15 +647,15 @@ function createBaseCommissionRates(): CommissionRates {
 export const CommissionRates = {
   encode(message: CommissionRates, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.rate !== "") {
-      writer.uint32(10).string(message.rate);
+      writer.uint32(10).string(Decimal.fromUserInput(message.rate, 18).atomics);
     }
 
     if (message.maxRate !== "") {
-      writer.uint32(18).string(message.maxRate);
+      writer.uint32(18).string(Decimal.fromUserInput(message.maxRate, 18).atomics);
     }
 
     if (message.maxChangeRate !== "") {
-      writer.uint32(26).string(message.maxChangeRate);
+      writer.uint32(26).string(Decimal.fromUserInput(message.maxChangeRate, 18).atomics);
     }
 
     return writer;
@@ -670,15 +671,15 @@ export const CommissionRates = {
 
       switch (tag >>> 3) {
         case 1:
-          message.rate = reader.string();
+          message.rate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.maxRate = reader.string();
+          message.maxRate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.maxChangeRate = reader.string();
+          message.maxChangeRate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -1004,7 +1005,7 @@ export const Validator = {
     }
 
     if (message.delegatorShares !== "") {
-      writer.uint32(50).string(message.delegatorShares);
+      writer.uint32(50).string(Decimal.fromUserInput(message.delegatorShares, 18).atomics);
     }
 
     if (message.description !== undefined) {
@@ -1060,7 +1061,7 @@ export const Validator = {
           break;
 
         case 6:
-          message.delegatorShares = reader.string();
+          message.delegatorShares = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 7:
@@ -1665,7 +1666,7 @@ export const Delegation = {
     }
 
     if (message.shares !== "") {
-      writer.uint32(26).string(message.shares);
+      writer.uint32(26).string(Decimal.fromUserInput(message.shares, 18).atomics);
     }
 
     return writer;
@@ -1689,7 +1690,7 @@ export const Delegation = {
           break;
 
         case 3:
-          message.shares = reader.string();
+          message.shares = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -2012,7 +2013,7 @@ export const RedelegationEntry = {
     }
 
     if (message.sharesDst !== "") {
-      writer.uint32(34).string(message.sharesDst);
+      writer.uint32(34).string(Decimal.fromUserInput(message.sharesDst, 18).atomics);
     }
 
     return writer;
@@ -2040,7 +2041,7 @@ export const RedelegationEntry = {
           break;
 
         case 4:
-          message.sharesDst = reader.string();
+          message.sharesDst = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -2274,7 +2275,7 @@ export const Params = {
     }
 
     if (message.minCommissionRate !== "") {
-      writer.uint32(50).string(message.minCommissionRate);
+      writer.uint32(50).string(Decimal.fromUserInput(message.minCommissionRate, 18).atomics);
     }
 
     return writer;
@@ -2310,7 +2311,7 @@ export const Params = {
           break;
 
         case 6:
-          message.minCommissionRate = reader.string();
+          message.minCommissionRate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/tx.ts
@@ -4,6 +4,7 @@ import { Coin, CoinSDKType } from "../../base/v1beta1/coin";
 import { Timestamp, TimestampSDKType } from "../../../google/protobuf/timestamp";
 import * as _m0 from "protobufjs/minimal";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "cosmos.staking.v1beta1";
 
 /** MsgCreateValidator defines a SDK message for creating a new validator. */
@@ -392,7 +393,7 @@ export const MsgEditValidator = {
     }
 
     if (message.commissionRate !== "") {
-      writer.uint32(26).string(message.commissionRate);
+      writer.uint32(26).string(Decimal.fromUserInput(message.commissionRate, 18).atomics);
     }
 
     if (message.minSelfDelegation !== "") {
@@ -420,7 +421,7 @@ export const MsgEditValidator = {
           break;
 
         case 3:
-          message.commissionRate = reader.string();
+          message.commissionRate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:

--- a/__fixtures__/v-next/outputv4/evmos/fees/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/fees/v1/genesis.ts
@@ -1,6 +1,7 @@
 import { DevFeeInfo, DevFeeInfoSDKType } from "./fees";
 import * as _m0 from "protobufjs/minimal";
 import { isSet, DeepPartial, Long } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "evmos.fees.v1";
 
 /** GenesisState defines the module's genesis state. */
@@ -173,11 +174,11 @@ export const Params = {
     }
 
     if (message.developerShares !== "") {
-      writer.uint32(18).string(message.developerShares);
+      writer.uint32(18).string(Decimal.fromUserInput(message.developerShares, 18).atomics);
     }
 
     if (message.validatorShares !== "") {
-      writer.uint32(26).string(message.validatorShares);
+      writer.uint32(26).string(Decimal.fromUserInput(message.validatorShares, 18).atomics);
     }
 
     if (!message.addrDerivationCostCreate.isZero()) {
@@ -185,7 +186,7 @@ export const Params = {
     }
 
     if (message.minGasPrice !== "") {
-      writer.uint32(42).string(message.minGasPrice);
+      writer.uint32(42).string(Decimal.fromUserInput(message.minGasPrice, 18).atomics);
     }
 
     return writer;
@@ -205,11 +206,11 @@ export const Params = {
           break;
 
         case 2:
-          message.developerShares = reader.string();
+          message.developerShares = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.validatorShares = reader.string();
+          message.validatorShares = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:
@@ -217,7 +218,7 @@ export const Params = {
           break;
 
         case 5:
-          message.minGasPrice = reader.string();
+          message.minGasPrice = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/evmos/incentives/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/incentives/v1/genesis.ts
@@ -1,6 +1,7 @@
 import { Incentive, IncentiveSDKType, GasMeter, GasMeterSDKType } from "./incentives";
 import * as _m0 from "protobufjs/minimal";
 import { isSet, DeepPartial } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "evmos.incentives.v1";
 
 /** GenesisState defines the module's genesis state. */
@@ -188,7 +189,7 @@ export const Params = {
     }
 
     if (message.allocationLimit !== "") {
-      writer.uint32(18).string(message.allocationLimit);
+      writer.uint32(18).string(Decimal.fromUserInput(message.allocationLimit, 18).atomics);
     }
 
     if (message.incentivesEpochIdentifier !== "") {
@@ -196,7 +197,7 @@ export const Params = {
     }
 
     if (message.rewardScaler !== "") {
-      writer.uint32(34).string(message.rewardScaler);
+      writer.uint32(34).string(Decimal.fromUserInput(message.rewardScaler, 18).atomics);
     }
 
     return writer;
@@ -216,7 +217,7 @@ export const Params = {
           break;
 
         case 2:
-          message.allocationLimit = reader.string();
+          message.allocationLimit = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
@@ -224,7 +225,7 @@ export const Params = {
           break;
 
         case 4:
-          message.rewardScaler = reader.string();
+          message.rewardScaler = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/evmos/inflation/v1/inflation.ts
+++ b/__fixtures__/v-next/outputv4/evmos/inflation/v1/inflation.ts
@@ -1,4 +1,5 @@
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial } from "../../../helpers";
 export const protobufPackage = "evmos.inflation.v1";
 
@@ -96,15 +97,15 @@ function createBaseInflationDistribution(): InflationDistribution {
 export const InflationDistribution = {
   encode(message: InflationDistribution, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.stakingRewards !== "") {
-      writer.uint32(10).string(message.stakingRewards);
+      writer.uint32(10).string(Decimal.fromUserInput(message.stakingRewards, 18).atomics);
     }
 
     if (message.usageIncentives !== "") {
-      writer.uint32(18).string(message.usageIncentives);
+      writer.uint32(18).string(Decimal.fromUserInput(message.usageIncentives, 18).atomics);
     }
 
     if (message.communityPool !== "") {
-      writer.uint32(26).string(message.communityPool);
+      writer.uint32(26).string(Decimal.fromUserInput(message.communityPool, 18).atomics);
     }
 
     return writer;
@@ -120,15 +121,15 @@ export const InflationDistribution = {
 
       switch (tag >>> 3) {
         case 1:
-          message.stakingRewards = reader.string();
+          message.stakingRewards = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.usageIncentives = reader.string();
+          message.usageIncentives = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.communityPool = reader.string();
+          message.communityPool = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -203,23 +204,23 @@ function createBaseExponentialCalculation(): ExponentialCalculation {
 export const ExponentialCalculation = {
   encode(message: ExponentialCalculation, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.a !== "") {
-      writer.uint32(10).string(message.a);
+      writer.uint32(10).string(Decimal.fromUserInput(message.a, 18).atomics);
     }
 
     if (message.r !== "") {
-      writer.uint32(18).string(message.r);
+      writer.uint32(18).string(Decimal.fromUserInput(message.r, 18).atomics);
     }
 
     if (message.c !== "") {
-      writer.uint32(26).string(message.c);
+      writer.uint32(26).string(Decimal.fromUserInput(message.c, 18).atomics);
     }
 
     if (message.bondingTarget !== "") {
-      writer.uint32(34).string(message.bondingTarget);
+      writer.uint32(34).string(Decimal.fromUserInput(message.bondingTarget, 18).atomics);
     }
 
     if (message.maxVariance !== "") {
-      writer.uint32(42).string(message.maxVariance);
+      writer.uint32(42).string(Decimal.fromUserInput(message.maxVariance, 18).atomics);
     }
 
     return writer;
@@ -235,23 +236,23 @@ export const ExponentialCalculation = {
 
       switch (tag >>> 3) {
         case 1:
-          message.a = reader.string();
+          message.a = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.r = reader.string();
+          message.r = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.c = reader.string();
+          message.c = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:
-          message.bondingTarget = reader.string();
+          message.bondingTarget = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 5:
-          message.maxVariance = reader.string();
+          message.maxVariance = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/evmos/inflation/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/inflation/v1/query.ts
@@ -2,6 +2,7 @@ import { DecCoin, DecCoinSDKType } from "../../../cosmos/base/v1beta1/coin";
 import { Params, ParamsSDKType } from "./genesis";
 import * as _m0 from "protobufjs/minimal";
 import { DeepPartial, Long, isSet } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "evmos.inflation.v1";
 
 /** QueryPeriodRequest is the request type for the Query/Period RPC method. */
@@ -743,7 +744,7 @@ function createBaseQueryInflationRateResponse(): QueryInflationRateResponse {
 export const QueryInflationRateResponse = {
   encode(message: QueryInflationRateResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.inflationRate !== "") {
-      writer.uint32(10).string(message.inflationRate);
+      writer.uint32(10).string(Decimal.fromUserInput(message.inflationRate, 18).atomics);
     }
 
     return writer;
@@ -759,7 +760,7 @@ export const QueryInflationRateResponse = {
 
       switch (tag >>> 3) {
         case 1:
-          message.inflationRate = reader.string();
+          message.inflationRate = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/balancerPool.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/balancerPool.ts
@@ -3,6 +3,7 @@ import { Duration, DurationSDKType } from "../../../../google/protobuf/duration"
 import { Coin, CoinSDKType } from "../../../../cosmos/base/v1beta1/coin";
 import * as _m0 from "protobufjs/minimal";
 import { toTimestamp, fromTimestamp, isSet, DeepPartial, Long } from "../../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "osmosis.gamm.v1beta1";
 
 /**
@@ -311,11 +312,11 @@ function createBasePoolParams(): PoolParams {
 export const PoolParams = {
   encode(message: PoolParams, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.swapFee !== "") {
-      writer.uint32(10).string(message.swapFee);
+      writer.uint32(10).string(Decimal.fromUserInput(message.swapFee, 18).atomics);
     }
 
     if (message.exitFee !== "") {
-      writer.uint32(18).string(message.exitFee);
+      writer.uint32(18).string(Decimal.fromUserInput(message.exitFee, 18).atomics);
     }
 
     if (message.smoothWeightChangeParams !== undefined) {
@@ -335,11 +336,11 @@ export const PoolParams = {
 
       switch (tag >>> 3) {
         case 1:
-          message.swapFee = reader.string();
+          message.swapFee = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.exitFee = reader.string();
+          message.exitFee = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/stableswap_pool.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/stableswap_pool.ts
@@ -1,5 +1,6 @@
 import { Coin, CoinSDKType } from "../../../../cosmos/base/v1beta1/coin";
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Long } from "../../../../helpers";
 export const protobufPackage = "osmosis.gamm.poolmodels.stableswap.v1beta1";
 
@@ -78,11 +79,11 @@ function createBasePoolParams(): PoolParams {
 export const PoolParams = {
   encode(message: PoolParams, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.swapFee !== "") {
-      writer.uint32(10).string(message.swapFee);
+      writer.uint32(10).string(Decimal.fromUserInput(message.swapFee, 18).atomics);
     }
 
     if (message.exitFee !== "") {
-      writer.uint32(18).string(message.exitFee);
+      writer.uint32(18).string(Decimal.fromUserInput(message.exitFee, 18).atomics);
     }
 
     return writer;
@@ -98,11 +99,11 @@ export const PoolParams = {
 
       switch (tag >>> 3) {
         case 1:
-          message.swapFee = reader.string();
+          message.swapFee = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.exitFee = reader.string();
+          message.exitFee = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/mint.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/mint.ts
@@ -1,4 +1,5 @@
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial, Long } from "../../../helpers";
 export const protobufPackage = "osmosis.mint.v1beta1";
 
@@ -142,7 +143,7 @@ function createBaseMinter(): Minter {
 export const Minter = {
   encode(message: Minter, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.epochProvisions !== "") {
-      writer.uint32(10).string(message.epochProvisions);
+      writer.uint32(10).string(Decimal.fromUserInput(message.epochProvisions, 18).atomics);
     }
 
     return writer;
@@ -158,7 +159,7 @@ export const Minter = {
 
       switch (tag >>> 3) {
         case 1:
-          message.epochProvisions = reader.string();
+          message.epochProvisions = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -222,7 +223,7 @@ export const WeightedAddress = {
     }
 
     if (message.weight !== "") {
-      writer.uint32(18).string(message.weight);
+      writer.uint32(18).string(Decimal.fromUserInput(message.weight, 18).atomics);
     }
 
     return writer;
@@ -242,7 +243,7 @@ export const WeightedAddress = {
           break;
 
         case 2:
-          message.weight = reader.string();
+          message.weight = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -310,19 +311,19 @@ function createBaseDistributionProportions(): DistributionProportions {
 export const DistributionProportions = {
   encode(message: DistributionProportions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.staking !== "") {
-      writer.uint32(10).string(message.staking);
+      writer.uint32(10).string(Decimal.fromUserInput(message.staking, 18).atomics);
     }
 
     if (message.poolIncentives !== "") {
-      writer.uint32(18).string(message.poolIncentives);
+      writer.uint32(18).string(Decimal.fromUserInput(message.poolIncentives, 18).atomics);
     }
 
     if (message.developerRewards !== "") {
-      writer.uint32(26).string(message.developerRewards);
+      writer.uint32(26).string(Decimal.fromUserInput(message.developerRewards, 18).atomics);
     }
 
     if (message.communityPool !== "") {
-      writer.uint32(34).string(message.communityPool);
+      writer.uint32(34).string(Decimal.fromUserInput(message.communityPool, 18).atomics);
     }
 
     return writer;
@@ -338,19 +339,19 @@ export const DistributionProportions = {
 
       switch (tag >>> 3) {
         case 1:
-          message.staking = reader.string();
+          message.staking = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 2:
-          message.poolIncentives = reader.string();
+          message.poolIncentives = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
-          message.developerRewards = reader.string();
+          message.developerRewards = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 4:
-          message.communityPool = reader.string();
+          message.communityPool = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -438,7 +439,7 @@ export const Params = {
     }
 
     if (message.genesisEpochProvisions !== "") {
-      writer.uint32(18).string(message.genesisEpochProvisions);
+      writer.uint32(18).string(Decimal.fromUserInput(message.genesisEpochProvisions, 18).atomics);
     }
 
     if (message.epochIdentifier !== "") {
@@ -450,7 +451,7 @@ export const Params = {
     }
 
     if (message.reductionFactor !== "") {
-      writer.uint32(42).string(message.reductionFactor);
+      writer.uint32(42).string(Decimal.fromUserInput(message.reductionFactor, 18).atomics);
     }
 
     if (message.distributionProportions !== undefined) {
@@ -482,7 +483,7 @@ export const Params = {
           break;
 
         case 2:
-          message.genesisEpochProvisions = reader.string();
+          message.genesisEpochProvisions = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 3:
@@ -494,7 +495,7 @@ export const Params = {
           break;
 
         case 5:
-          message.reductionFactor = reader.string();
+          message.reductionFactor = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 6:

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/params.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/params.ts
@@ -1,4 +1,5 @@
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 import { isSet, DeepPartial } from "../../helpers";
 export const protobufPackage = "osmosis.superfluid";
 
@@ -27,7 +28,7 @@ function createBaseParams(): Params {
 export const Params = {
   encode(message: Params, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.minimumRiskFactor !== "") {
-      writer.uint32(10).string(message.minimumRiskFactor);
+      writer.uint32(10).string(Decimal.fromUserInput(message.minimumRiskFactor, 18).atomics);
     }
 
     return writer;
@@ -43,7 +44,7 @@ export const Params = {
 
       switch (tag >>> 3) {
         case 1:
-          message.minimumRiskFactor = reader.string();
+          message.minimumRiskFactor = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/superfluid.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/superfluid.ts
@@ -1,6 +1,7 @@
 import { Coin, CoinSDKType } from "../../cosmos/base/v1beta1/coin";
 import * as _m0 from "protobufjs/minimal";
 import { isSet, DeepPartial, Long } from "../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "osmosis.superfluid";
 
 /**
@@ -379,7 +380,7 @@ export const OsmoEquivalentMultiplierRecord = {
     }
 
     if (message.multiplier !== "") {
-      writer.uint32(26).string(message.multiplier);
+      writer.uint32(26).string(Decimal.fromUserInput(message.multiplier, 18).atomics);
     }
 
     return writer;
@@ -403,7 +404,7 @@ export const OsmoEquivalentMultiplierRecord = {
           break;
 
         case 3:
-          message.multiplier = reader.string();
+          message.multiplier = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/query.ts
@@ -2,6 +2,7 @@ import { Timestamp, TimestampSDKType } from "../../../google/protobuf/timestamp"
 import { Params, ParamsSDKType } from "./genesis";
 import { Long, toTimestamp, fromTimestamp, isSet, DeepPartial } from "../../../helpers";
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "osmosis.twap.v1beta1";
 export interface ArithmeticTwapRequest {
   poolId: Long;
@@ -194,7 +195,7 @@ function createBaseArithmeticTwapResponse(): ArithmeticTwapResponse {
 export const ArithmeticTwapResponse = {
   encode(message: ArithmeticTwapResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.arithmeticTwap !== "") {
-      writer.uint32(10).string(message.arithmeticTwap);
+      writer.uint32(10).string(Decimal.fromUserInput(message.arithmeticTwap, 18).atomics);
     }
 
     return writer;
@@ -210,7 +211,7 @@ export const ArithmeticTwapResponse = {
 
       switch (tag >>> 3) {
         case 1:
-          message.arithmeticTwap = reader.string();
+          message.arithmeticTwap = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:
@@ -389,7 +390,7 @@ function createBaseArithmeticTwapToNowResponse(): ArithmeticTwapToNowResponse {
 export const ArithmeticTwapToNowResponse = {
   encode(message: ArithmeticTwapToNowResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.arithmeticTwap !== "") {
-      writer.uint32(10).string(message.arithmeticTwap);
+      writer.uint32(10).string(Decimal.fromUserInput(message.arithmeticTwap, 18).atomics);
     }
 
     return writer;
@@ -405,7 +406,7 @@ export const ArithmeticTwapToNowResponse = {
 
       switch (tag >>> 3) {
         case 1:
-          message.arithmeticTwap = reader.string();
+          message.arithmeticTwap = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/twap_record.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/twap_record.ts
@@ -1,6 +1,7 @@
 import { Timestamp, TimestampSDKType } from "../../../google/protobuf/timestamp";
 import { Long, toTimestamp, fromTimestamp, isSet, DeepPartial } from "../../../helpers";
 import * as _m0 from "protobufjs/minimal";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "osmosis.twap.v1beta1";
 
 /**
@@ -107,19 +108,19 @@ export const TwapRecord = {
     }
 
     if (message.p0LastSpotPrice !== "") {
-      writer.uint32(50).string(message.p0LastSpotPrice);
+      writer.uint32(50).string(Decimal.fromUserInput(message.p0LastSpotPrice, 18).atomics);
     }
 
     if (message.p1LastSpotPrice !== "") {
-      writer.uint32(58).string(message.p1LastSpotPrice);
+      writer.uint32(58).string(Decimal.fromUserInput(message.p1LastSpotPrice, 18).atomics);
     }
 
     if (message.p0ArithmeticTwapAccumulator !== "") {
-      writer.uint32(66).string(message.p0ArithmeticTwapAccumulator);
+      writer.uint32(66).string(Decimal.fromUserInput(message.p0ArithmeticTwapAccumulator, 18).atomics);
     }
 
     if (message.p1ArithmeticTwapAccumulator !== "") {
-      writer.uint32(74).string(message.p1ArithmeticTwapAccumulator);
+      writer.uint32(74).string(Decimal.fromUserInput(message.p1ArithmeticTwapAccumulator, 18).atomics);
     }
 
     if (message.lastErrorTime !== undefined) {
@@ -159,19 +160,19 @@ export const TwapRecord = {
           break;
 
         case 6:
-          message.p0LastSpotPrice = reader.string();
+          message.p0LastSpotPrice = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 7:
-          message.p1LastSpotPrice = reader.string();
+          message.p1LastSpotPrice = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 8:
-          message.p0ArithmeticTwapAccumulator = reader.string();
+          message.p0ArithmeticTwapAccumulator = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 9:
-          message.p1ArithmeticTwapAccumulator = reader.string();
+          message.p1ArithmeticTwapAccumulator = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         case 11:

--- a/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/query.ts
@@ -1,6 +1,7 @@
 import { FeeToken, FeeTokenSDKType } from "./feetoken";
 import * as _m0 from "protobufjs/minimal";
 import { DeepPartial, isSet, Long } from "../../../helpers";
+import { Decimal } from "@cosmjs/math";
 export const protobufPackage = "osmosis.txfees.v1beta1";
 export interface QueryFeeTokensRequest {}
 export interface QueryFeeTokensRequestSDKType {}
@@ -297,7 +298,7 @@ export const QueryDenomSpotPriceResponse = {
     }
 
     if (message.spotPrice !== "") {
-      writer.uint32(18).string(message.spotPrice);
+      writer.uint32(18).string(Decimal.fromUserInput(message.spotPrice, 18).atomics);
     }
 
     return writer;
@@ -317,7 +318,7 @@ export const QueryDenomSpotPriceResponse = {
           break;
 
         case 2:
-          message.spotPrice = reader.string();
+          message.spotPrice = Decimal.fromAtomics(reader.string(), 18).toString();
           break;
 
         default:

--- a/packages/ast/src/encoding/__snapshots__/object.spec.ts.snap
+++ b/packages/ast/src/encoding/__snapshots__/object.spec.ts.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cosmos/staking/v1beta1 Delegation 1`] = `
+"export const Delegation = {
+  encode(message: Delegation, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.delegatorAddress !== "") {
+      writer.uint32(10).string(message.delegatorAddress);
+    }
+
+    if (message.validatorAddress !== "") {
+      writer.uint32(18).string(message.validatorAddress);
+    }
+
+    if (message.shares !== "") {
+      writer.uint32(26).string(Decimal.fromUserInput(message.shares, 18).atomics);
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Delegation {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDelegation();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.delegatorAddress = reader.string();
+          break;
+
+        case 2:
+          message.validatorAddress = reader.string();
+          break;
+
+        case 3:
+          message.shares = Decimal.fromAtomics(reader.string(), 18).toString();
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromJSON(object: any): Delegation {
+    return {
+      delegatorAddress: isSet(object.delegatorAddress) ? String(object.delegatorAddress) : "",
+      validatorAddress: isSet(object.validatorAddress) ? String(object.validatorAddress) : "",
+      shares: isSet(object.shares) ? String(object.shares) : ""
+    };
+  },
+
+  toJSON(message: Delegation): unknown {
+    const obj: any = {};
+    message.delegatorAddress !== undefined && (obj.delegatorAddress = message.delegatorAddress);
+    message.validatorAddress !== undefined && (obj.validatorAddress = message.validatorAddress);
+    message.shares !== undefined && (obj.shares = message.shares);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<Delegation>): Delegation {
+    const message = createBaseDelegation();
+    message.delegatorAddress = object.delegatorAddress ?? "";
+    message.validatorAddress = object.validatorAddress ?? "";
+    message.shares = object.shares ?? "";
+    return message;
+  },
+
+  fromSDK(object: DelegationSDKType): Delegation {
+    return {
+      delegatorAddress: object?.delegator_address,
+      validatorAddress: object?.validator_address,
+      shares: object?.shares
+    };
+  },
+
+  toSDK(message: Delegation): DelegationSDKType {
+    const obj: any = {};
+    obj.delegator_address = message.delegatorAddress;
+    obj.validator_address = message.validatorAddress;
+    obj.shares = message.shares;
+    return obj;
+  }
+
+};"
+`;
+
 exports[`cosmos/tx/signing/v1beta1/signing SignatureDescriptor 1`] = `
 "export const SignatureDescriptor = {
   encode(message: SignatureDescriptor, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {

--- a/packages/ast/src/encoding/object.spec.ts
+++ b/packages/ast/src/encoding/object.spec.ts
@@ -131,6 +131,19 @@ describe('cosmos/tx/v1beta1/tx', () => {
     })
 });
 
+describe('cosmos/staking/v1beta1', () => {
+  const ref = store.findProto('cosmos/staking/v1beta1/staking.proto');
+  const res = traverse(store, ref);
+  it('Delegation', () => {
+      const context = new ProtoParseContext(ref, store, defaultTelescopeOptions);
+      context.options.prototypes!.typingsFormat!.customTypes!.useCosmosSDKDec = true;
+      expectCode(createObjectWithMethods(
+          context,
+          'Delegation', getNestedProto(res).Delegation
+      ))
+  })
+});
+
 describe('google/api/expr/v1alpha1/checked', () => {
     const ref = store.findProto('google/api/expr/v1alpha1/checked.proto');
     const res = traverse(store, ref);

--- a/packages/ast/src/encoding/proto/decode/utils.ts
+++ b/packages/ast/src/encoding/proto/decode/utils.ts
@@ -168,13 +168,43 @@ export const baseTypes = {
 
     // reader.string();
     string(args: DecodeMethod) {
-        return t.callExpression(
+        const useCosmosSDKDec = args.context.pluginValue(
+          'prototypes.typingsFormat.customTypes.useCosmosSDKDec'
+        );
+        const isCosmosSDKDec =
+          args.field.options?.['(gogoproto.customtype)'] ==
+          'github.com/cosmos/cosmos-sdk/types.Dec';
+
+        let valueExpression = t.callExpression(
             t.memberExpression(
                 t.identifier('reader'),
                 t.identifier('string')
             ),
             []
         );
+
+        if(useCosmosSDKDec && isCosmosSDKDec){
+          args.context.addUtil("Decimal");
+
+          valueExpression = t.callExpression(
+            t.memberExpression(
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier('Decimal'),
+                  t.identifier('fromAtomics'),
+                ),
+                [
+                  valueExpression,
+                  t.numericLiteral(18)
+                ]
+              ),
+              t.identifier('toString'),
+            ),
+            []
+          )
+        }
+
+        return valueExpression;
     },
 
     // reader.bool();

--- a/packages/ast/types/src/encoding/proto/encode/utils.d.ts
+++ b/packages/ast/types/src/encoding/proto/encode/utils.d.ts
@@ -28,7 +28,7 @@ export declare const encode: {
     keyHash(args: EncodeMethod): t.ExpressionStatement;
 };
 export declare const types: {
-    string(num: number, prop: string, isOptional: boolean): t.IfStatement;
+    string(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
     double(num: number, prop: string, isOptional: boolean): t.IfStatement;
     float(num: number, prop: string, isOptional: boolean): t.IfStatement;
     int32(num: number, prop: string, isOptional: boolean): t.IfStatement;

--- a/packages/ast/types/test-utils/index.d.ts
+++ b/packages/ast/types/test-utils/index.d.ts
@@ -5,6 +5,7 @@ import { GenericParseContext } from '../src/encoding';
 export declare const expectCode: (ast: any) => void;
 export declare const printCode: (ast: any) => void;
 export declare const defaultTelescopeOptions: {
+    env: "default" | "v-next";
     experimentalGlobalProtoNamespace: boolean;
     removeUnusedImports: boolean;
     classesUseArrowFunctions: boolean;
@@ -50,6 +51,9 @@ export declare const defaultTelescopeOptions: {
             protos?: string[];
         };
         typingsFormat?: {
+            customTypes?: {
+                useCosmosSDKDec?: boolean;
+            };
             useDeepPartial?: boolean;
             useExact?: boolean;
             timestamp?: "date" | "timestamp";

--- a/packages/telescope/__tests__/telescope-v4.test.ts
+++ b/packages/telescope/__tests__/telescope-v4.test.ts
@@ -65,6 +65,9 @@ const options: TelescopeOptions = {
       protos: ['cosmos/authz/v1beta1/event.proto']
     },
     typingsFormat: {
+      customTypes: {
+        useCosmosSDKDec: true
+      },
       useDeepPartial: true,
       useExact: false,
       timestamp: 'date',

--- a/packages/telescope/src/utils/index.ts
+++ b/packages/telescope/src/utils/index.ts
@@ -19,6 +19,7 @@ export const UTILS = {
   base64FromBytes: '__helpers__',
   bytesFromBase64: '__helpers__',
   BrowserHeaders: 'browser-headers',
+  Decimal: '@cosmjs/math',
   createProtobufRpcClient: '@cosmjs/stargate',
   decodeBech32Pubkey: '@cosmjs/amino',
   DeepPartial: '__helpers__',

--- a/packages/telescope/types/utils/index.d.ts
+++ b/packages/telescope/types/utils/index.d.ts
@@ -13,6 +13,7 @@ export declare const UTILS: {
     base64FromBytes: string;
     bytesFromBase64: string;
     BrowserHeaders: string;
+    Decimal: string;
     createProtobufRpcClient: string;
     decodeBech32Pubkey: string;
     DeepPartial: string;

--- a/packages/types/src/telescope.ts
+++ b/packages/types/src/telescope.ts
@@ -64,6 +64,9 @@ interface TelescopeOpts {
             protos?: string[];
         };
         typingsFormat?: {
+            customTypes?:{
+              useCosmosSDKDec?: boolean;
+            },
             useDeepPartial?: boolean;
             useExact?: boolean;
             timestamp?: 'date' | 'timestamp',
@@ -234,6 +237,9 @@ export const defaultTelescopeOptions: TelescopeOptions = {
         optionalPageRequests: false,
 
         typingsFormat: {
+            customTypes: {
+              useCosmosSDKDec: false
+            },
             useDeepPartial: true,
             useExact: false,
             timestamp: 'date',

--- a/packages/types/types/telescope.d.ts
+++ b/packages/types/types/telescope.d.ts
@@ -54,6 +54,9 @@ interface TelescopeOpts {
             protos?: string[];
         };
         typingsFormat?: {
+            customTypes?: {
+                useCosmosSDKDec?: boolean;
+            };
             useDeepPartial?: boolean;
             useExact?: boolean;
             timestamp?: 'date' | 'timestamp';


### PR DESCRIPTION
handled all fields with (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec" when encoding and decoding.
added a flag in option: "typingsFormat.customTypes.useCosmosSDKDec"
regenerated output-v4

Now all decimal fields are handled like these:
        encode: writer.uint32(10).string(Decimal.fromUserInput(message.rate, 18).atomics);
        decode: message.rate = Decimal.fromAtomics(reader.string(), 18).toString();
        