### PR TITLE
allow for includes option for various modules and leverage dependency resolution

### DIFF
--- a/packages/ast/src/encoding/proto/implements/decoder.ts
+++ b/packages/ast/src/encoding/proto/implements/decoder.ts
@@ -51,13 +51,6 @@ export const createInterfaceDecoderHelper = (
   // MARKED AS NOT DRY
   const allTypes: TypeUrlRef[] =
     typeRefs?.reduce((m, typeRef) => {
-      // check excludes
-      const packages =
-        context.pluginValue('prototypes.excluded.packages') ?? [];
-      const protos = context.pluginValue('prototypes.excluded.protos') ?? [];
-      const excluded =
-        packages.includes(typeRef.pkg) || protos.includes(typeRef.ref);
-      if (excluded) return m;
       return [...m, ...typeRef.types];
     }, []) ?? [];
 

--- a/packages/ast/src/encoding/proto/implements/from-amino.ts
+++ b/packages/ast/src/encoding/proto/implements/from-amino.ts
@@ -103,11 +103,6 @@ export const createInterfaceFromAminoHelper = (
 
     // MARKED AS NOT DRY
     const allTypes: TypeUrlRef[] = typeRefs?.reduce((m, typeRef) => {
-        // check excludes
-        const packages = context.pluginValue('prototypes.excluded.packages') ?? [];
-        const protos = context.pluginValue('prototypes.excluded.protos') ?? [];
-        const excluded = packages.includes(typeRef.pkg) || protos.includes(typeRef.ref);
-        if (excluded) return m;
         return [...m, ...typeRef.types];
     }, []) ?? [];
 

--- a/packages/ast/src/encoding/proto/implements/to-amino.ts
+++ b/packages/ast/src/encoding/proto/implements/to-amino.ts
@@ -96,11 +96,6 @@ export const createInterfaceToAminoHelper = (
 
     // MARKED AS NOT DRY
     const allTypes: TypeUrlRef[] = typeRefs?.reduce((m, typeRef) => {
-        // check excludes
-        const packages = context.pluginValue('prototypes.excluded.packages') ?? [];
-        const protos = context.pluginValue('prototypes.excluded.protos') ?? [];
-        const excluded = packages.includes(typeRef.pkg) || protos.includes(typeRef.ref);
-        if (excluded) return m;
         return [...m, ...typeRef.types];
     }, []) ?? [];
 

--- a/packages/ast/types/test-utils/index.d.ts
+++ b/packages/ast/types/test-utils/index.d.ts
@@ -49,6 +49,10 @@ export declare const defaultTelescopeOptions: {
             packages?: string[];
             protos?: string[];
         };
+        includes?: {
+            packages?: string[];
+            protos?: string[];
+        };
         typingsFormat?: {
             customTypes?: {
                 useCosmosSDKDec?: boolean;

--- a/packages/parser/__tests__/store/__snapshots__/store.test.ts.snap
+++ b/packages/parser/__tests__/store/__snapshots__/store.test.ts.snap
@@ -1,0 +1,216 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cosmos/gov/v1beta1/gov.proto 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "cosmos.gov.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.protobuf",
+]
+`;
+
+exports[`cosmos/gov/v1beta1/gov.proto excluded 1`] = `[]`;
+
+exports[`cosmos/gov/v1beta1/gov.proto excluded dep 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "cosmos.gov.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.protobuf",
+]
+`;
+
+exports[`get all packages 1`] = `
+[
+  "akash.audit.v1beta1",
+  "akash.audit.v1beta2",
+  "akash.base.v1beta1",
+  "akash.base.v1beta2",
+  "akash.cert.v1beta2",
+  "akash.deployment.v1beta1",
+  "akash.deployment.v1beta2",
+  "akash.escrow.v1beta1",
+  "akash.escrow.v1beta2",
+  "akash.inflation.v1beta2",
+  "akash.market.v1beta2",
+  "akash.provider.v1beta1",
+  "akash.provider.v1beta2",
+  "cosmos.app.v1alpha1",
+  "cosmos.auth.v1beta1",
+  "cosmos.authz.v1beta1",
+  "cosmos.bank.v1beta1",
+  "cosmos.base.abci.v1beta1",
+  "cosmos.base.kv.v1beta1",
+  "cosmos.base.query.v1beta1",
+  "cosmos.base.reflection.v1beta1",
+  "cosmos.base.reflection.v2alpha1",
+  "cosmos.base.snapshots.v1beta1",
+  "cosmos.base.store.v1beta1",
+  "cosmos.base.tendermint.v1beta1",
+  "cosmos.base.v1beta1",
+  "cosmos.capability.v1beta1",
+  "cosmos.crisis.v1beta1",
+  "cosmos.crypto.ed25519",
+  "cosmos.crypto.hd.v1",
+  "cosmos.crypto.keyring.v1",
+  "cosmos.crypto.multisig",
+  "cosmos.crypto.multisig.v1beta1",
+  "cosmos.crypto.secp256k1",
+  "cosmos.crypto.secp256r1",
+  "cosmos.distribution.v1beta1",
+  "cosmos.evidence.v1beta1",
+  "cosmos.feegrant.v1beta1",
+  "cosmos.genutil.v1beta1",
+  "cosmos.gov.v1",
+  "cosmos.gov.v1beta1",
+  "cosmos.group.v1",
+  "cosmos.mint.v1beta1",
+  "cosmos.msg.v1",
+  "cosmos.nft.v1beta1",
+  "cosmos.orm.module.v1alpha1",
+  "cosmos.orm.v1",
+  "cosmos.orm.v1alpha1",
+  "cosmos.params.v1beta1",
+  "cosmos.slashing.v1beta1",
+  "cosmos.staking.v1beta1",
+  "cosmos.tx.signing.v1beta1",
+  "cosmos.tx.v1beta1",
+  "cosmos.upgrade.v1beta1",
+  "cosmos.vesting.v1beta1",
+  "cosmos_proto",
+  "cosmwasm.wasm.v1",
+  "evmos.claims.v1",
+  "evmos.epochs.v1",
+  "evmos.erc20.v1",
+  "evmos.fees.v1",
+  "evmos.incentives.v1",
+  "evmos.inflation.v1",
+  "evmos.recovery.v1",
+  "evmos.vesting.v1",
+  "gogoproto",
+  "google.api",
+  "google.api.expr.conformance.v1alpha1",
+  "google.api.expr.v1alpha1",
+  "google.api.expr.v1beta1",
+  "google.api.servicecontrol.v1",
+  "google.api.servicecontrol.v2",
+  "google.api.servicemanagement.v1",
+  "google.api.serviceusage.v1",
+  "google.api.serviceusage.v1beta1",
+  "google.logging.type",
+  "google.logging.v2",
+  "google.longrunning",
+  "google.protobuf",
+  "google.protobuf.compiler",
+  "google.rpc",
+  "google.rpc.context",
+  "ibc.applications.transfer.v1",
+  "ibc.applications.transfer.v2",
+  "ibc.core.channel.v1",
+  "ibc.core.client.v1",
+  "ibc.core.commitment.v1",
+  "ibc.core.connection.v1",
+  "ibc.core.port.v1",
+  "ibc.core.types.v1",
+  "ibc.lightclients.localhost.v1",
+  "ibc.lightclients.solomachine.v1",
+  "ibc.lightclients.solomachine.v2",
+  "ibc.lightclients.tendermint.v1",
+  "ics23",
+  "osmosis.claim.v1beta1",
+  "osmosis.epochs.v1beta1",
+  "osmosis.gamm.poolmodels.balancer.v1beta1",
+  "osmosis.gamm.poolmodels.stableswap.v1beta1",
+  "osmosis.gamm.v1beta1",
+  "osmosis.gamm.v2",
+  "osmosis.ibcratelimit.v1beta1",
+  "osmosis.incentives",
+  "osmosis.lockup",
+  "osmosis.mint.v1beta1",
+  "osmosis.poolincentives.v1beta1",
+  "osmosis.store.v1beta1",
+  "osmosis.superfluid",
+  "osmosis.superfluid.v1beta1",
+  "osmosis.tokenfactory.v1beta1",
+  "osmosis.twap.v1beta1",
+  "osmosis.txfees.v1beta1",
+  "tendermint.abci",
+  "tendermint.crypto",
+  "tendermint.libs.bits",
+  "tendermint.p2p",
+  "tendermint.types",
+  "tendermint.version",
+]
+`;
+
+exports[`gov.proto & tx.proto & signing.proto 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "cosmos.crypto.multisig.v1beta1",
+  "cosmos.gov.v1beta1",
+  "cosmos.tx.signing.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.protobuf",
+  "osmosis.gamm.v1beta1",
+]
+`;
+
+exports[`gov.proto & tx.proto & signing.proto excluded 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "cosmos.crypto.multisig.v1beta1",
+  "cosmos.gov.v1beta1",
+  "cosmos.tx.signing.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.protobuf",
+]
+`;
+
+exports[`gov.proto & tx.proto 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "cosmos.gov.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.protobuf",
+  "osmosis.gamm.v1beta1",
+]
+`;
+
+exports[`osmosis excluded gamm 1`] = `
+[
+  "cosmos.bank.v1beta1",
+  "cosmos.base.query.v1beta1",
+  "cosmos.base.v1beta1",
+  "cosmos.staking.v1beta1",
+  "cosmos_proto",
+  "gogoproto",
+  "google.api",
+  "google.protobuf",
+  "osmosis.claim.v1beta1",
+  "osmosis.epochs.v1beta1",
+  "osmosis.ibcratelimit.v1beta1",
+  "osmosis.incentives",
+  "osmosis.lockup",
+  "osmosis.mint.v1beta1",
+  "osmosis.poolincentives.v1beta1",
+  "osmosis.store.v1beta1",
+  "osmosis.superfluid",
+  "osmosis.superfluid.v1beta1",
+  "osmosis.tokenfactory.v1beta1",
+  "osmosis.twap.v1beta1",
+  "osmosis.txfees.v1beta1",
+]
+`;
+
+exports[`osmosis/gamm/v1beta1/tx.proto 1`] = `
+[
+  "cosmos.base.v1beta1",
+  "gogoproto",
+  "osmosis.gamm.v1beta1",
+]
+`;

--- a/packages/parser/__tests__/store/__snapshots__/store.test.ts.snap
+++ b/packages/parser/__tests__/store/__snapshots__/store.test.ts.snap
@@ -186,6 +186,7 @@ exports[`osmosis excluded gamm 1`] = `
   "cosmos.bank.v1beta1",
   "cosmos.base.query.v1beta1",
   "cosmos.base.v1beta1",
+  "cosmos.msg.v1",
   "cosmos.staking.v1beta1",
   "cosmos_proto",
   "gogoproto",
@@ -204,13 +205,18 @@ exports[`osmosis excluded gamm 1`] = `
   "osmosis.tokenfactory.v1beta1",
   "osmosis.twap.v1beta1",
   "osmosis.txfees.v1beta1",
+  "tendermint.crypto",
+  "tendermint.types",
+  "tendermint.version",
 ]
 `;
 
 exports[`osmosis/gamm/v1beta1/tx.proto 1`] = `
 [
   "cosmos.base.v1beta1",
+  "cosmos_proto",
   "gogoproto",
+  "google.protobuf",
   "osmosis.gamm.v1beta1",
 ]
 `;

--- a/packages/parser/__tests__/store/store.test.ts
+++ b/packages/parser/__tests__/store/store.test.ts
@@ -1,0 +1,126 @@
+import { getTestProtoStore } from '../../test-utils';
+
+it('get all packages', () => {
+  const store = getTestProtoStore();
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('cosmos/gov/v1beta1/gov.proto', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:["cosmos/gov/v1beta1/gov.proto"]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('cosmos/gov/v1beta1/gov.proto excluded', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:["cosmos/gov/v1beta1/gov.proto"]
+  }
+  store.options.prototypes!.excluded = {
+    protos:["cosmos/gov/v1beta1/gov.proto"]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('cosmos/gov/v1beta1/gov.proto excluded dep', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:["cosmos/gov/v1beta1/gov.proto"]
+  }
+  store.options.prototypes!.excluded = {
+    protos:["gogoproto/gogo.proto"]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('osmosis/gamm/v1beta1/tx.proto', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:["osmosis/gamm/v1beta1/tx.proto"]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('gov.proto & tx.proto', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:[
+      "cosmos/gov/v1beta1/gov.proto",
+      "osmosis/gamm/v1beta1/tx.proto"
+    ]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('gov.proto & tx.proto & signing.proto', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:[
+      "cosmos/gov/v1beta1/gov.proto",
+      "osmosis/gamm/v1beta1/tx.proto",
+      "cosmos/tx/signing/v1beta1/signing.proto"
+    ]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('gov.proto & tx.proto & signing.proto excluded', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    protos:[
+      "cosmos/gov/v1beta1/gov.proto",
+      "osmosis/gamm/v1beta1/tx.proto",
+      "cosmos/tx/signing/v1beta1/signing.proto"
+    ]
+  }
+  store.options.prototypes!.excluded = {
+    protos:[
+      "**/gamm/**",
+    ]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});
+
+it('osmosis excluded gamm', () => {
+  const store = getTestProtoStore();
+  store.options.prototypes!.includes = {
+    packages:[
+      "osmosis.*"
+    ]
+  }
+  store.options.prototypes!.excluded = {
+    protos:[
+      "**/gamm/**",
+    ]
+  }
+  store.traverseAll();
+  const pkgs = store.getPackages().sort();
+
+  expect(pkgs).toMatchSnapshot();
+});

--- a/packages/parser/__tests__/traverse/bad.traversal.test.ts
+++ b/packages/parser/__tests__/traverse/bad.traversal.test.ts
@@ -36,7 +36,7 @@ message MyMessage {
         store.traverseAll();
     } catch (e) {
         failed = true;
-        expect(e.message).toEqual('missing proto import gogoproto/gogo.proto')
+        expect(e.message).toEqual('Dependency Not Found gogoproto/gogo.proto')
     }
     expect(failed).toBe(true);
 });

--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -111,26 +111,26 @@ export const isRefIncluded = (
     }
 
     // TODO consider deprecating `patterns` in favor of packages and protos supporting minimatch
-    if (include?.patterns?.some(pattern => Boolean(ref.filename) && minimatch(ref.filename, pattern))) {
+    if (Boolean(ref.filename) && include?.patterns?.some(pattern => minimatch(ref.filename, pattern))) {
         return true;
     }
 
-    const pkgMatched = include?.packages?.some(pkgName => {
+    const pkgMatched = Boolean(ref.proto?.package) && include?.packages?.some(pkgName => {
         if (!globPattern.test(pkgName)) {
             return ref.proto.package === pkgName;
         }
-        return Boolean(ref.proto?.package) && minimatch(ref.proto.package, pkgName)
+        return minimatch(ref.proto.package, pkgName)
     });
 
     if (pkgMatched) {
         return true;
     }
 
-    const protoMatched = include?.protos?.some(protoName => {
+    const protoMatched = Boolean(ref.filename) && include?.protos?.some(protoName => {
         if (!globPattern.test(protoName)) {
             return ref.filename === protoName;
         }
-        return Boolean(ref.filename) && minimatch(ref.filename, protoName)
+        return minimatch(ref.filename, protoName)
     });
 
     if (protoMatched) {

--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -111,7 +111,7 @@ export const isRefIncluded = (
     }
 
     // TODO consider deprecating `patterns` in favor of packages and protos supporting minimatch
-    if (include?.patterns?.some(pattern => minimatch(ref.filename, pattern))) {
+    if (include?.patterns?.some(pattern => Boolean(ref.filename) && minimatch(ref.filename, pattern))) {
         return true;
     }
 
@@ -119,7 +119,7 @@ export const isRefIncluded = (
         if (!globPattern.test(pkgName)) {
             return ref.proto.package === pkgName;
         }
-        return minimatch(ref.proto.package, pkgName)
+        return Boolean(ref.proto?.package) && minimatch(ref.proto.package, pkgName)
     });
 
     if (pkgMatched) {
@@ -130,7 +130,7 @@ export const isRefIncluded = (
         if (!globPattern.test(protoName)) {
             return ref.filename === protoName;
         }
-        return minimatch(ref.filename, protoName)
+        return Boolean(ref.filename) && minimatch(ref.filename, protoName)
     });
 
     if (protoMatched) {

--- a/packages/telescope/src/commands/transpile.ts
+++ b/packages/telescope/src/commands/transpile.ts
@@ -30,6 +30,18 @@ export default async (argv) => {
       default: './src/codegen'
     },
     {
+      _: true,
+      type: 'path',
+      name: 'build',
+      message: 'which files to include. ex: osmosis/**/gamm/**/*.proto or cosmos/bank/v1beta1/bank.proto',
+    },
+    {
+      _: true,
+      type: 'path',
+      name: 'nobuild',
+      message: 'which files to exclude. ex: osmosis/**/gamm/**/*.proto or cosmos/bank/v1beta1/bank.proto',
+    },
+    {
       type: 'confirm',
       name: 'includeAminos',
       message: 'output amino messages?',
@@ -52,6 +64,8 @@ export default async (argv) => {
   let {
     protoDirs,
     outPath,
+    build,
+    nobuild,
     includeAminos,
     includeLCDClients,
     includeRPCClients,
@@ -61,7 +75,7 @@ export default async (argv) => {
     protoDirs = [protoDirs];
   }
 
-  const options = {
+  const options: any = {
     aminoEncoding: {
       enabled: includeAminos
     },
@@ -72,6 +86,37 @@ export default async (argv) => {
       enabled: includeRPCClients,
     }
   };
+
+  if(build || nobuild){
+    if(!options.prototypes){
+      options.prototypes = {}
+    }
+
+  }
+
+  if(build){
+    if (!Array.isArray(build)) {
+      build = [build];
+    }
+
+    if(!options.prototypes.includes){
+      options.prototypes.includes = {}
+    }
+
+    options.prototypes.includes.protos = build;
+  }
+
+  if(nobuild){
+    if (!Array.isArray(nobuild)) {
+      nobuild = [nobuild];
+    }
+
+    if(!options.prototypes.excluded){
+      options.prototypes.excluded = {}
+    }
+
+    options.prototypes.excluded.protos = nobuild;
+  }
 
   writeFileSync(
     process.cwd() + '/.telescope.json',

--- a/packages/telescope/src/generators/create-amino-converters.ts
+++ b/packages/telescope/src/generators/create-amino-converters.ts
@@ -24,10 +24,6 @@ export const plugin = (
             return;
         }
 
-        if (c.proto.isExcluded()) {
-            return;
-        }
-
         const localname = bundler.getLocalFilename(c.ref, 'amino');
         const filename = bundler.getFilename(localname);
         const ctx = bundler.getFreshContext(c);

--- a/packages/telescope/src/generators/create-types.ts
+++ b/packages/telescope/src/generators/create-types.ts
@@ -22,8 +22,6 @@ export const plugin = (
     bundler.contexts = baseProtos.map(ref => {
         const context = builder.context(ref);
 
-        if (isRefExcluded(ref, builder.options.prototypes?.excluded)) return;
-
         parse(context);
         context.buildBase();
 

--- a/packages/types/src/telescope.ts
+++ b/packages/types/src/telescope.ts
@@ -62,6 +62,11 @@ interface TelescopeOpts {
             packages?: string[];
             protos?: string[];
         };
+        includes?: {
+          packages?: string[];
+          protos?: string[];
+        };
+
         typingsFormat?: {
             customTypes?:{
               useCosmosSDKDec?: boolean;

--- a/packages/types/types/telescope.d.ts
+++ b/packages/types/types/telescope.d.ts
@@ -52,6 +52,10 @@ interface TelescopeOpts {
             packages?: string[];
             protos?: string[];
         };
+        includes?: {
+            packages?: string[];
+            protos?: string[];
+        };
         typingsFormat?: {
             customTypes?: {
                 useCosmosSDKDec?: boolean;


### PR DESCRIPTION
https://github.com/osmosis-labs/telescope/issues/352

add includes option to telescope options
add --build and --nobuild options to cli
unit tested.
tested by using:
  yarn dev transpile --protoDirs ../../__fixtures__/chain1 --build 'cosmos/**' --build 'osmosis/**' --nobuild '**/gamm/**'

Logic:
  dependencies(imported) will always be included, even though it's in excluded(or nobuild).
  files matches prototypes.includes will be included, except the files matches prototypes.excluded.
