### PR TITLE
fix: update CI pnpm version from 9 to 10 to match lockfile

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - name: node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - name: node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# fix: update CI pnpm version from 9 to 10 to match lockfile

## Summary

CI was failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the lockfile (including `patchedDependencies` for `@chain-registry/client@2.0.162`) was generated with pnpm 10, but the CI workflows were pinned to pnpm 9. This updates `version: 9` → `version: 10` in both `run-tests.yaml` and `run-e2e-tests.yaml`.

## Review & Testing Checklist for Human

- [ ] Verify the `telescope-tests` CI job passes (install, build, and all test steps)
- [ ] Verify the `e2e-tests` CI job still works with pnpm 10 (starship integration)

### Notes
- [Devin run](https://app.devin.ai/sessions/e7438c4ecc7242ef86b62f3c009a0851)
- Requested by @pyramation
- Failing run: https://github.com/hyperweb-io/telescope/actions/runs/22510226316/job/65217740739
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperweb-io/telescope/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
