### PR TITLE
fix: restore DeliverTxResponse type in react-query mutation hooks

### DIFF
--- a/packages/telescope/src/helpers/react-query-hooks-icjs.ts
+++ b/packages/telescope/src/helpers/react-query-hooks-icjs.ts
@@ -14,7 +14,7 @@ import {
 import { ISigningClient, isISigningClient } from "@interchainjs/cosmos";
 import {
   StdFee,
-
+  DeliverTxResponse,
 } from './types${options.restoreImportExtension ?? ""}'
 import {
     useQuery,
@@ -177,7 +177,7 @@ export interface UseMutationBuilderOptions<TMsg> {
     message: TMsg | TMsg[],
     fee: StdFee | 'auto',
     memo: string
-  ) => Promise<any>,
+  ) => Promise<DeliverTxResponse>,
 }
 
 const getSigningClientFromCache = (
@@ -193,7 +193,7 @@ export function buildUseMutation<TMsg, TError>(opts: UseMutationBuilderOptions<T
   return ({
     options,
     clientResolver
-  }: ReactMutationParams<any, TError, ITxArgs<TMsg>>) => {
+  }: ReactMutationParams<DeliverTxResponse, TError, ITxArgs<TMsg>>) => {
     const queryClient = useQueryClient({
       context: options?.context
     });
@@ -213,9 +213,9 @@ export function buildUseMutation<TMsg, TError>(opts: UseMutationBuilderOptions<T
       signingClientResolver = cachedClient || (!isCacheResolver(clientResolver) ? clientResolver : undefined);
     }
 
-    return useMutation<any, Error, ITxArgs<TMsg>>(
+    return useMutation<DeliverTxResponse, Error, ITxArgs<TMsg>>(
       (reqData: ITxArgs<TMsg>) => opts.builderMutationFn(signingClientResolver!, reqData.signerAddress, reqData.message, reqData.fee, reqData.memo),
-      options as Omit<UseMutationOptions<any, Error, ITxArgs<TMsg>, unknown>, "mutationFn">
+      options as Omit<UseMutationOptions<DeliverTxResponse, Error, ITxArgs<TMsg>, unknown>, "mutationFn">
     );
   };
 }

--- a/packages/telescope/src/helpers/react-query-hooks.ts
+++ b/packages/telescope/src/helpers/react-query-hooks.ts
@@ -11,7 +11,7 @@ import {
 } from './helpers${options.restoreImportExtension ?? ""}'
  import {
   StdFee,
-
+  DeliverTxResponse,
 } from './types${options.restoreImportExtension ?? ""}'
 import {
   ITxArgs,
@@ -218,7 +218,7 @@ export interface UseMutationBuilderOptions<TMsg> {
     message: TMsg | TMsg[],
     fee: StdFee | 'auto',
     memo: string
-  ) => Promise<any>,
+  ) => Promise<DeliverTxResponse>,
 }
 
 const getSigningClientFromCache = (
@@ -234,7 +234,7 @@ export function buildUseMutation<TMsg, TError>(opts: UseMutationBuilderOptions<T
   return ({
     options,
     clientResolver
-  }: ReactMutationParams<any, TError, ITxArgs<TMsg>>) => {
+  }: ReactMutationParams<DeliverTxResponse, TError, ITxArgs<TMsg>>) => {
     const queryClient = useQueryClient({
       context: options?.context
     });
@@ -256,9 +256,9 @@ export function buildUseMutation<TMsg, TError>(opts: UseMutationBuilderOptions<T
 
     const mutationFn = opts.builderMutationFn(signingClientResolver);
 
-    return useMutation<any, Error, ITxArgs<TMsg>>(
+    return useMutation<DeliverTxResponse, Error, ITxArgs<TMsg>>(
       (reqData: ITxArgs<TMsg>) => mutationFn(reqData.signerAddress, reqData.message, reqData.fee, reqData.memo),
-      options as Omit<UseMutationOptions<any, Error, ITxArgs<TMsg>, unknown>, "mutationFn">
+      options as Omit<UseMutationOptions<DeliverTxResponse, Error, ITxArgs<TMsg>, unknown>, "mutationFn">
     );
   };
 }


### PR DESCRIPTION
follow up of #782

#763 introduced a regression by replacing DeliverTxResponse with any.
#782 tried to fix this but missed useMutation generic.