### PR TITLE
fix: num64 == "long" generates broken helper files

### DIFF
--- a/packages/telescope/src/helpers/binary-runtime.ts
+++ b/packages/telescope/src/helpers/binary-runtime.ts
@@ -1,0 +1,48 @@
+import { TelescopeOptions } from "@cosmology/types";
+
+const restoreImportExtension = (options: TelescopeOptions) =>
+  options.restoreImportExtension ?? "";
+
+export const isBigint64 = (options: TelescopeOptions) =>
+  options.prototypes.typingsFormat.num64 === "bigint";
+
+export const getBinaryRuntimeImport = (options: TelescopeOptions) =>
+  isBigint64(options)
+    ? `import { BinaryReader, BinaryWriter } from "./binary${restoreImportExtension(
+        options
+      )}";`
+    : 'import * as _m0 from "protobufjs/minimal";';
+
+export const getBinaryReaderImport = (options: TelescopeOptions) =>
+  isBigint64(options)
+    ? `import { BinaryReader } from "./binary${restoreImportExtension(
+        options
+      )}";`
+    : 'import * as _m0 from "protobufjs/minimal";';
+
+export const getBinaryTypesImport = (options: TelescopeOptions) =>
+  isBigint64(options)
+    ? `import { IBinaryReader, IBinaryWriter } from "./binary${restoreImportExtension(
+        options
+      )}";`
+    : 'import * as _m0 from "protobufjs/minimal";';
+
+export const getReaderTypeRef = (options: TelescopeOptions) =>
+  isBigint64(options) ? "BinaryReader" : "_m0.Reader";
+
+export const getWriterTypeRef = (options: TelescopeOptions) =>
+  isBigint64(options) ? "BinaryWriter" : "_m0.Writer";
+
+export const getTypesReaderTypeRef = (options: TelescopeOptions) =>
+  isBigint64(options) ? "IBinaryReader" : "_m0.Reader";
+
+export const getTypesWriterTypeRef = (options: TelescopeOptions) =>
+  isBigint64(options) ? "IBinaryWriter" : "_m0.Writer";
+
+export const getReaderInstanceExpr = (
+  options: TelescopeOptions,
+  expression: string
+) =>
+  isBigint64(options)
+    ? `${expression} instanceof BinaryReader ? ${expression} : new BinaryReader(${expression})`
+    : `${expression} instanceof _m0.Reader ? ${expression} : new _m0.Reader(${expression})`;

--- a/packages/telescope/src/helpers/helper-func-types-interface.ts
+++ b/packages/telescope/src/helpers/helper-func-types-interface.ts
@@ -1,9 +1,17 @@
 import { TelescopeOptions } from "@cosmology/types";
+import {
+  getBinaryRuntimeImport,
+  getReaderTypeRef,
+  getWriterTypeRef,
+} from "./binary-runtime";
 
 export const getHelperFuncTypesForInterface = (options: TelescopeOptions) => {
+  const readerType = getReaderTypeRef(options);
+  const writerType = getWriterTypeRef(options);
+
   return `
 import { HttpEndpoint } from "@interchainjs/types";
-import { BinaryReader, BinaryWriter } from "./binary${options.restoreImportExtension ?? ""}";${!options.isGeneratingCosmosTypes ? `
+${getBinaryRuntimeImport(options)}${!options.isGeneratingCosmosTypes ? `
 import { getRpcClient } from "./extern${options.restoreImportExtension ?? ""}";` : ''}
 import { isRpc, Rpc } from "./helpers${options.restoreImportExtension ?? ""}";${!options.isGeneratingCosmosTypes ? `
 import { TelescopeGeneratedCodec, DeliverTxResponse, Message, StdFee } from "./types${options.restoreImportExtension ?? ""}";` : ''}${!options.isGeneratingCosmosTypes ? `
@@ -11,8 +19,8 @@ import { toConverters, toEncoders } from "@interchainjs/cosmos";
 import { ISigningClient } from "@interchainjs/cosmos";` : ''}
 
 export interface QueryBuilderOptions<TReq, TRes> {
-  encode: (request: TReq, writer?: BinaryWriter) => BinaryWriter
-  decode: (input: BinaryReader | Uint8Array, length?: number) => TRes
+  encode: (request: TReq, writer?: ${writerType}) => ${writerType}
+  decode: (input: ${readerType} | Uint8Array, length?: number) => TRes
   service: string,
   method: string,
   deps?: TelescopeGeneratedCodec<any, any, any>[],

--- a/packages/telescope/src/helpers/helper-func-types.ts
+++ b/packages/telescope/src/helpers/helper-func-types.ts
@@ -1,9 +1,17 @@
 import { TelescopeOptions } from "@cosmology/types";
+import {
+  getBinaryRuntimeImport,
+  getReaderTypeRef,
+  getWriterTypeRef,
+} from "./binary-runtime";
 
 export const getHelperFuncTypes = (options: TelescopeOptions) => {
+  const readerType = getReaderTypeRef(options);
+  const writerType = getWriterTypeRef(options);
+
   return `
 import { HttpEndpoint } from "@interchainjs/types";
-import { BinaryReader, BinaryWriter } from "./binary${options.restoreImportExtension ?? ""}";${!options.isGeneratingCosmosTypes ? `
+${getBinaryRuntimeImport(options)}${!options.isGeneratingCosmosTypes ? `
 import { getRpcClient } from "./extern${options.restoreImportExtension ?? ""}";` : ''}
 import { isRpc, Rpc } from "./helpers${options.restoreImportExtension ?? ""}";${!options.isGeneratingCosmosTypes ? `
 import { TelescopeGeneratedCodec, DeliverTxResponse, Message, StdFee } from "./types${options.restoreImportExtension ?? ""}";` : ''}${!options.isGeneratingCosmosTypes ? `
@@ -11,8 +19,8 @@ import { toConverters, toEncoders } from "@interchainjs/cosmos";
 import { ISigningClient } from "@interchainjs/cosmos";` : ''}
 
 export interface QueryBuilderOptions<TReq, TRes> {
-  encode: (request: TReq, writer?: BinaryWriter) => BinaryWriter
-  decode: (input: BinaryReader | Uint8Array, length?: number) => TRes
+  encode: (request: TReq, writer?: ${writerType}) => ${writerType}
+  decode: (input: ${readerType} | Uint8Array, length?: number) => TRes
   service: string,
   method: string,
 }

--- a/packages/telescope/src/helpers/registry-helper.ts
+++ b/packages/telescope/src/helpers/registry-helper.ts
@@ -1,7 +1,14 @@
 import { TelescopeOptions } from "@cosmology/types";
+import {
+  getBinaryReaderImport,
+  getReaderInstanceExpr,
+  getReaderTypeRef,
+} from "./binary-runtime";
 
 export const getRegistryHelper = (options: TelescopeOptions) => {
-  return `import { BinaryReader } from "./binary${options.restoreImportExtension ?? ""}";
+  const readerType = getReaderTypeRef(options);
+
+  return `${getBinaryReaderImport(options)}
 import { Any, AnyAmino } from "./google/protobuf/any${options.restoreImportExtension ?? ""}";
 import { IProtoType, TelescopeGeneratedCodec } from "./types${options.restoreImportExtension ?? ""}";
 
@@ -105,14 +112,13 @@ export class GlobalDecoderRegistry {
       value: decoder.encode(obj).finish(),
     };
   }
-  static unwrapAny<T, SDK, Amino>(input: BinaryReader | Uint8Array | Any) {
+  static unwrapAny<T, SDK, Amino>(input: ${readerType} | Uint8Array | Any) {
     let data;
 
     if (Any.is(input)) {
       data = input;
     } else {
-      const reader =
-        input instanceof BinaryReader ? input : new BinaryReader(input);
+      const reader = ${getReaderInstanceExpr(options, "input")};
 
       data = Any.decode(reader, reader.uint32());
     }

--- a/packages/telescope/src/helpers/types-helper.ts
+++ b/packages/telescope/src/helpers/types-helper.ts
@@ -1,9 +1,15 @@
 import { TelescopeOptions } from "@cosmology/types";
+import {
+  getBinaryTypesImport,
+  getTypesReaderTypeRef,
+  getTypesWriterTypeRef,
+} from "./binary-runtime";
 
 export const getTypesHelper = (options: TelescopeOptions) => {
-  return `import { IBinaryReader, IBinaryWriter } from "./binary${
-    options.restoreImportExtension ?? ""
-  }";
+  const readerType = getTypesReaderTypeRef(options);
+  const writerType = getTypesWriterTypeRef(options);
+
+  return `${getBinaryTypesImport(options)}
 import { Any } from "./google/protobuf/any${
     options.restoreImportExtension ?? ""
   }";
@@ -42,8 +48,8 @@ export interface TelescopeGeneratedCodec<
   is?(o: unknown): o is T;
   isSDK?(o: unknown): o is SDK;
   isAmino?(o: unknown): o is Amino;
-  encode: (message: T, writer?: IBinaryWriter | any) => IBinaryWriter | any;
-  decode: (input: IBinaryReader | Uint8Array | any, length?: number) => T;
+  encode: (message: T, writer?: ${writerType} | any) => ${writerType} | any;
+  decode: (input: ${readerType} | Uint8Array | any, length?: number) => T;
   fromPartial: (object: any) => T | any;
   fromJSON?: (object: any) => T | any;
   toJSON?: (message: T | any) => any;


### PR DESCRIPTION
When configured to use `Long` for 64-bit numbers instead of `bigint`, certain helper files like `helper-func-types.ts` are still being generated to import `./binary` and use `BinaryReader`/`BinaryWriter` for param type definitions, where they shouldn't be.

`src/types/binary.ts`, `src/types/utf8.ts`, and `src/types/varint.ts` are not even generated when configured to use `Long` for 64-bit numbers, so while it's not only incorrect, it also causes build issues in packages importing a package generated using telescope because of the missing imports.

This change makes the helper templates use the right encoding/decoding mechanisms, and removes broken imports:
- num64: "bigint" continues to use BinaryReader / BinaryWriter from ./binary
- num64: "long" now uses _m0.Reader / _m0.Writer from protobufjs/minimal as it should